### PR TITLE
fix invalid printf formats

### DIFF
--- a/benchmark.ml
+++ b/benchmark.ml
@@ -532,8 +532,8 @@ let string_of_rate display_as_rate =
       if display_as_rate then r, err else
         let n = 1. /. r in (n, n *. n *. err) (* Taylor of order 1 of 1/r *) in
     let p prec =
-      if sigma < 1e-15 then (sprintf " %0.*f%s" prec a per_sec, "")
-      else (sprintf " %0.*f+-" prec a, sprintf "%.*f%s" prec err per_sec) in
+      if sigma < 1e-15 then (sprintf " %.*f%s" prec a per_sec, "")
+      else (sprintf " %.*f+-" prec a, sprintf "%.*f%s" prec err per_sec) in
     if a >= 100. then p 0
     else if a >= 10. then p 1
     else if a >= 1.  then p 2


### PR DESCRIPTION
There are some format strings that are "invalid" in the benchmark sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of benchmark, I think the behavior has not changed between 4.01.0 and 4.02.0. The only kind of invalid format is "%0._f". This is considered invalid beause it specifies a padding character (with the flag 0), but no minimum field width (no number before the dot) so there will never be padding. Even though the behaviour has not changed, you should take the opportunity to review the code and fix the format. The patch changes it to "%._f", which keeps the behaviour unchanged, but that might still be wrong.
