### PR TITLE
Use Re.Pcre instead of Pcre

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -20,7 +20,7 @@ all: byte opt native
 byte: $(EXAMPLES:.ml=.exe)
 opt native:  $(EXAMPLES:.ml=.com)
 
-regexps.exe regexps.com: REQUIRES += pcre
+regexps.exe regexps.com: REQUIRES += re
 
 %.exe: %.ml ../benchmark.cma
 	$(OCAMLC) -o $@ $(ALL_OPTS) -linkpkg $(BENCHMARK) $<

--- a/examples/dune
+++ b/examples/dune
@@ -2,7 +2,7 @@
 (executables
  (names ar_ba composition iter let_try loops
         match_array numbers regexps try_if func_record)
- (libraries benchmark bigarray str pcre))
+ (libraries benchmark bigarray str re))
 
 (alias
  (name examples)

--- a/examples/regexps.ml
+++ b/examples/regexps.ml
@@ -1,3 +1,4 @@
+module Pcre = Re.Pcre
 open Printf
 open Benchmark
 


### PR DESCRIPTION
Rationale: Pcre depends on an obsolete library:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1000004