### PR TITLE
add GC statistics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 PKGVERSION = $(shell git describe --always)
 PKGTARBALL = benchmark-$(PKGVERSION).tbz
 
+DUNE_OPTS?=
+
 all build byte native:
-	dune build @install @tests @examples
+	dune build $(DUNE_OPTS) @install @tests @examples
 
 install uninstall:
 	dune $@
@@ -10,7 +12,7 @@ install uninstall:
 doc:
 	sed -e 's/%%VERSION%%/$(PKGVERSION)/' benchmark.mli \
 	  > _build/default/benchmark.mli
-	dune build @doc
+	dune build $(DUNE_OPTS) @doc
 	@echo '.def { background: #f0f0f0; }' \
 	  >> _build/default/_doc/_html/odoc.css
 
@@ -20,4 +22,9 @@ lint:
 clean:
 	dune clean
 
-.PHONY: all build byte native install uninstall doc lint clean
+WATCH?=@install
+watch:
+	dune build $(DUNE_OPTS) $(WATCH) -w
+
+
+.PHONY: all build byte native install uninstall doc lint clean watch

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.1)
+(name benchmark)

--- a/examples/ar_ba.ml
+++ b/examples/ar_ba.ml
@@ -99,6 +99,7 @@ let () =
     ] in
   print_endline "Sum of elements or set all elements to 3.:";
   tabulate res;
+  print_gc res;
 
   let res = throughputN ~repeat:3 3
     [("ba", ba_alloc, ());
@@ -108,3 +109,4 @@ let () =
     ] in
   print_endline "With allocation:";
   tabulate res;
+  print_gc res

--- a/examples/composition.ml
+++ b/examples/composition.ml
@@ -45,4 +45,5 @@ let () =
 
   let res = throughputN ~repeat:3 5 [("fun", do_f, ());
                                      ("vec", do_v, ()) ] in
-  tabulate res
+  tabulate res;
+  print_gc res

--- a/examples/func_record.ml
+++ b/examples/func_record.ml
@@ -32,7 +32,8 @@ let () =
      ("no arg", (fun () -> h 1.), ());
     ] in
   print_endline "Functor vesus records vesus passing as arg:";
-  tabulate res
+  tabulate res;
+  print_gc res
 
 (* Local Variables: *)
 (* compile-command: "make -k -C .." *)

--- a/examples/loops.ml
+++ b/examples/loops.ml
@@ -31,4 +31,5 @@ let () =
               [("rec", rec_loop, a);
                ("rec2", rec_loop2, a);
                ("for", for_loop, a); ] in
-  tabulate res
+  tabulate res;
+  print_gc res

--- a/examples/match_array.ml
+++ b/examples/match_array.ml
@@ -36,5 +36,6 @@ open Benchmark
 let () =
   let res = throughputN 3 ~repeat:5 [ ("arr", f1, ());
 				      ("pat", f2, ()); ] in
-  tabulate res
+  tabulate res;
+  print_gc res
 

--- a/examples/numbers.ml
+++ b/examples/numbers.ml
@@ -32,7 +32,8 @@ let () =
 
   (* let's exercise the *1 functions: *)
   let _ = latency1 ~name:"int-1-lat" 1000L f_int 10000 in
-  let _ = throughput1 ~name:"int-1-thru" 5 f_int 10000 in
+  let s = throughput1 ~name:"int-1-thru" 5 f_int 10000 in
+  print_gc s;
   print_newline ();
 
   (* now let's exercise the *N functions: *)
@@ -42,6 +43,7 @@ let () =
                ("int64", f_int64, 10000); ] in
   print_newline ();
   tabulate res;
+  print_gc res;
 
   print_newline ();
   let res = latencyN 2000L [("int",   f_int,   10000);

--- a/examples/try_if.ml
+++ b/examples/try_if.ml
@@ -31,4 +31,5 @@ let () =
                                      ("try", f1, ());
                                      ("if", f2, ())  ] in
   print_endline "Bigarray bound checking:";
-  tabulate res
+  tabulate res;
+  print_gc res

--- a/src/benchmark.ml
+++ b/src/benchmark.ml
@@ -668,7 +668,7 @@ let print_gc  (results:( _ * t list) list) : unit =
   let major_rates = List.map (compute_per_iter get_major) results in
 
   (* Compute rows *)
-  let top_row = ["" ; " minor allocs/iter" ; " major allocs/iter"; ] in
+  let top_row = ["" ; " minor_allocs/iter" ; " major_allocs/iter"; ] in
   let rows = top_row :: List.map2 (fun (name, minor) (_, major) ->
     [name; string_of_bytes minor; string_of_bytes major]) minor_rates major_rates
   in

--- a/src/benchmark.ml
+++ b/src/benchmark.ml
@@ -168,6 +168,7 @@ let max_iter = Int64.add (Int64.of_int max_int) 1L
    0L] times [f] with the argument [x].  The structure returned
    declare [n_iter] iterations. *)
 let runloop n_iters n f x =
+  Gc.minor();
   let n' = Int64.div n max_iter in
   if n' >= max_iter then
     invalid_arg "Benchmark.runloop: number of iterations too large";
@@ -219,7 +220,9 @@ let latency n out ?min_count ?min_cpu ~style ?fwidth ?fdigits
   let rec loop nrep acc =
     if nrep < 1 then acc
     else (
+      Gc.full_major();
       Gc.compact(); (* Reclaim memory to avoid undue GC during the test. *)
+      Gc.minor();
       let bm, _ = timeit n f x in
       print_run out ?min_count ?min_cpu ~style ?fwidth ?fdigits bm;
       loop (nrep - 1) (bm :: acc)
@@ -251,7 +254,9 @@ let throughput tmin out ?min_count ?min_cpu ~style ?fwidth ?fdigits
   (* Repeat the test [nrep] times and return the list of results. *)
   let rec repeat_test nrep acc nmin niter wall_estim =
     if nrep < 1 then acc else (
+      Gc.full_major();
       Gc.compact(); (* Reclaim memory to avoid undue GC during the test. *)
+      Gc.minor();
       let bm, wall = run_test nmin niter null_t 0. in
       let wall_estim =
         if wall > wall_estim +. 60. then (

--- a/src/benchmark.ml
+++ b/src/benchmark.ml
@@ -669,7 +669,7 @@ let print_gc  (results:( _ * t list) list) : unit =
 
   (* Compute rows *)
   let top_row = ["" ; " minor_allocs/iter" ; " major_allocs/iter"; ] in
-  let rows = top_row :: List.map2 (fun (name, minor) (_, major) ->
+  let rows = List.map2 (fun (name, minor) (_, major) ->
     [name; string_of_bytes minor; string_of_bytes major]) minor_rates major_rates
   in
 

--- a/src/benchmark.mli
+++ b/src/benchmark.mli
@@ -62,6 +62,9 @@ type t = {
   cutime : float; (** Child process User CPU time (in seconds) *)
   cstime : float; (** Child process System CPU time (in seconds) *)
   iters : Int64.t;  (** Number of iterations. *)
+  minor_words: float; (** Bytes allocated on minor heap *)
+  major_words: float; (** Bytes allocated on major heap, incl. promoted *)
+  promoted_words: float; (** Bytes moved from minor heap to major heap *)
 }
 
 (** Style of the output. *)
@@ -228,7 +231,8 @@ val tabulate : ?no_parent:bool -> ?confidence:float -> samples -> unit
     @param confidence is used to determine the confidence interval for
     the Student's test.  (default: [0.95]).  *)
 
-
+val print_gc : samples -> unit
+(** Print GC statistics. *)
 
 (** {2 Benchmark Tree}
 
@@ -337,9 +341,11 @@ module Tree : sig
       use something like [Arg.parse (specs @ more_specs) ...] to make
       the above arguments available to the program user.  *)
 
-  val run : ?arg: arg_state -> ?paths: path list ->  ?out: Format.formatter ->
+  val run : ?with_gc:bool ->
+            ?arg: arg_state -> ?paths: path list ->  ?out: Format.formatter ->
             t -> unit
   (** [run t] runs all benchmarks of [t] and print the results to [fmt].
+      @param with_gc if true, will print GC statistics as well (Default: true)
       @param paths if provided, only the sub-trees corresponding to
         these path is executed.  Default: execute everything.
       @param out The formatter on which to print the output.


### PR DESCRIPTION
this is WIP, but the idea is to collect statistics on allocations (using `Gc.counters()`) and display averages on them. This gives a pretty insightful view on which implementations allocate more, which is often (but not always) correlated with slowness.
